### PR TITLE
fix: packages with two versions

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,8 +3,9 @@ import chalk from 'chalk';
 import { renderChart } from './chart.js';
 import { parseCliOptions, showHelp } from './cli-options.js';
 import { getColors } from './colors.js';
+import { formatDownloads } from './format.js';
 import { fetchNpmLastWeekDownloads, type NpmLastWeekDownloadsResponse } from './npm-api.js';
-import { groupByType, type GroupedStats, pickTopStats } from './stats.js';
+import { groupStats, pickTopStats } from './stats.js';
 import { parseVersion, versionCompare } from './version.js';
 
 export async function pkgStats(argv: string[]) {
@@ -33,7 +34,7 @@ export async function pkgStats(argv: string[]) {
     process.exit(1);
   }
 
-  const rawStats = Object.keys(data.downloads)
+  const npmStats = Object.keys(data.downloads)
     .map((versionString) => {
       const version = parseVersion(versionString);
       return {
@@ -43,46 +44,28 @@ export async function pkgStats(argv: string[]) {
     })
     .sort(versionCompare);
 
-  const groupedStats: GroupedStats[] = groupByType(options.group, rawStats);
-  const totalDownloads = Object.values(groupedStats).reduce(
-    (sum, version) => sum + version.downloads,
-    0,
-  );
+  const { type, stats } = groupStats(npmStats, options.group);
+  const totalDownloads = Object.values(stats).reduce((sum, version) => sum + version.downloads, 0);
 
-  const groupedStatsToDisplay = options.top
-    ? pickTopStats(groupedStats, options.top)
-    : groupedStats;
-
-  const colors = getColors(groupedStatsToDisplay.length, options.color);
+  const statsToDisplay = options.top ? pickTopStats(stats, options.top) : stats;
+  const colors = getColors(statsToDisplay.length, options.color);
   const primaryColor = chalk.hex(colors[0]);
 
   console.log(chalk.bold(`\nNPM weekly downloads for ${primaryColor(options.packageName)}\n`));
   console.log(`Total: ${primaryColor(totalDownloads.toLocaleString())} last week\n`);
 
-  console.log(options.top ? `Top ${options.top} versions:\n` : 'By version:\n');
+  console.log(options.top ? `Top ${options.top} ${type} versions:\n` : `By ${type} version:\n`);
 
-  const maxDownloads = Math.max(...groupedStats.map((v) => v.downloads));
-  groupedStatsToDisplay.forEach((item, i) => {
+  const maxDownloads = Math.max(...stats.map((v) => v.downloads));
+  statsToDisplay.forEach((item, i) => {
     const versionParts = item.versionString.split('.');
-    const version = versionParts.length < 3 ? `${item.versionString}.x` : item.versionString;
+    const versionString = versionParts.length < 3 ? `${item.versionString}.x` : item.versionString;
     const chart = renderChart(item.downloads / maxDownloads);
     const downloads = formatDownloads(item.downloads, maxDownloads);
     const color = chalk.hex(colors[i]);
 
-    console.log(`${version.padStart(8)} ${color(chart)} ${color(downloads.padStart(6))}`);
+    console.log(`${versionString.padStart(8)} ${color(chart)} ${color(downloads.padStart(6))}`);
   });
 
   console.log('');
-}
-
-function formatDownloads(downloads: number, maxDownloads: number) {
-  if (maxDownloads > 1000000) {
-    return `${(downloads / 1000000).toFixed(1)}M`;
-  }
-
-  if (maxDownloads > 1000) {
-    return `${(downloads / 1000).toFixed(1)}K`;
-  }
-
-  return downloads.toString();
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,11 @@
+export function formatDownloads(downloads: number, maxDownloads: number) {
+  if (maxDownloads > 1000000) {
+    return `${(downloads / 1000000).toFixed(1)}M`;
+  }
+
+  if (maxDownloads > 1000) {
+    return `${(downloads / 1000).toFixed(1)}K`;
+  }
+
+  return downloads.toString();
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -30,12 +30,12 @@ export function groupByType(type: GroupType | undefined, stats: NpmStats[]): Gro
   }
 
   const groupedByMajor = groupByMajor(stats);
-  if (groupedByMajor.length > 1) {
+  if (groupedByMajor.length >= 3) {
     return groupedByMajor;
   }
 
   const groupedByMinor = groupByMinor(stats);
-  if (groupedByMinor.length > 1) {
+  if (groupedByMinor.length >= 3) {
     return groupedByMinor;
   }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -16,30 +16,35 @@ export type GroupedStats = {
 
 export type GroupType = 'major' | 'minor' | 'patch';
 
-export function groupByType(type: GroupType | undefined, stats: NpmStats[]): GroupedStats[] {
+export type GroupStatsResult = {
+  type: GroupType;
+  stats: GroupedStats[];
+};
+
+export function groupStats(stats: NpmStats[], type: GroupType | undefined): GroupStatsResult {
   if (type === 'major') {
-    return groupByMajor(stats);
+    return { type: 'major', stats: groupByMajor(stats) };
   }
 
   if (type === 'minor') {
-    return groupByMinor(stats);
+    return { type: 'minor', stats: groupByMinor(stats) };
   }
 
   if (type === 'patch') {
-    return groupByPatch(stats);
+    return { type: 'patch', stats: groupByPatch(stats) };
   }
 
   const groupedByMajor = groupByMajor(stats);
   if (groupedByMajor.length >= 3) {
-    return groupedByMajor;
+    return { type: 'major', stats: groupedByMajor };
   }
 
   const groupedByMinor = groupByMinor(stats);
   if (groupedByMinor.length >= 3) {
-    return groupedByMinor;
+    return { type: 'minor', stats: groupedByMinor };
   }
 
-  return groupByPatch(stats);
+  return { type: 'patch', stats: groupByPatch(stats) };
 }
 
 function groupByMajor(stats: NpmStats[]): GroupedStats[] {


### PR DESCRIPTION
## Summary

Fix cases like RN which had only two (major versions): 1000.x (nightlies) and 0.x (all normal releases).

Now the grouping level will drop if there are not enough 3 groups.