### PR TITLE
feat: hide negligible versions by default

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,7 +5,7 @@ import { parseCliOptions, showHelp } from './cli-options.js';
 import { getColors } from './colors.js';
 import { formatDownloads } from './format.js';
 import { fetchNpmLastWeekDownloads, type NpmLastWeekDownloadsResponse } from './npm-api.js';
-import { groupStats, pickMinimalDownloads, pickTopStats } from './stats.js';
+import { filterStats, groupStats } from './stats.js';
 import { parseVersion, versionCompare } from './version.js';
 
 export async function pkgStats(argv: string[]) {
@@ -47,11 +47,11 @@ export async function pkgStats(argv: string[]) {
   const { type, stats } = groupStats(npmStats, options.group);
   const totalDownloads = Object.values(stats).reduce((sum, version) => sum + version.downloads, 0);
 
-  let statsToDisplay = stats;
-  statsToDisplay = options.top ? pickTopStats(statsToDisplay, options.top) : statsToDisplay;
-  statsToDisplay = !options.all
-    ? pickMinimalDownloads(statsToDisplay, totalDownloads * 0.005)
-    : statsToDisplay;
+  const statsToDisplay = filterStats(stats, {
+    totalDownloads,
+    all: options.all,
+    top: options.top,
+  });
 
   const colors = getColors(statsToDisplay.length, options.color);
   const primaryColor = chalk.hex(colors[0]);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,7 +5,7 @@ import { parseCliOptions, showHelp } from './cli-options.js';
 import { getColors } from './colors.js';
 import { formatDownloads } from './format.js';
 import { fetchNpmLastWeekDownloads, type NpmLastWeekDownloadsResponse } from './npm-api.js';
-import { groupStats, pickTopStats } from './stats.js';
+import { groupStats, pickMinimalDownloads, pickTopStats } from './stats.js';
 import { parseVersion, versionCompare } from './version.js';
 
 export async function pkgStats(argv: string[]) {
@@ -47,7 +47,12 @@ export async function pkgStats(argv: string[]) {
   const { type, stats } = groupStats(npmStats, options.group);
   const totalDownloads = Object.values(stats).reduce((sum, version) => sum + version.downloads, 0);
 
-  const statsToDisplay = options.top ? pickTopStats(stats, options.top) : stats;
+  let statsToDisplay = stats;
+  statsToDisplay = options.top ? pickTopStats(statsToDisplay, options.top) : statsToDisplay;
+  statsToDisplay = !options.all
+    ? pickMinimalDownloads(statsToDisplay, totalDownloads * 0.005)
+    : statsToDisplay;
+
   const colors = getColors(statsToDisplay.length, options.color);
   const primaryColor = chalk.hex(colors[0]);
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -14,6 +14,7 @@ Options:
   --minor               Group by minor version
   --patch               Group by patch version
   -t, --top <number>    Show top <number> versions
+  -a, --all             Show ALL versions (even negligible ones)
   -c, --color <color>   Color scheme: ${COLOR_SCHEMES.sort().join(', ')}
 `;
 
@@ -25,6 +26,7 @@ export type CliOptions = {
   packageName: string;
   group?: 'major' | 'minor' | 'patch';
   top?: number;
+  all?: boolean;
   color?: ColorScheme;
 };
 
@@ -53,6 +55,10 @@ export function parseCliOptions(argv: string[]): CliOptions {
         shortFlag: 't',
         type: 'number',
       },
+      all: {
+        type: 'boolean',
+        shortFlag: 'a',
+      },
       color: {
         shortFlag: 'c',
         type: 'string',
@@ -79,6 +85,7 @@ export function parseCliOptions(argv: string[]): CliOptions {
       ? 'patch'
       : undefined,
     top: cli.flags.top,
+    all: cli.flags.all,
     color: cli.flags.color as ColorScheme,
   };
 }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -102,12 +102,27 @@ function groupByPatch(stats: NpmStats[]) {
   return Object.values(result).sort((a, b) => versionCompare(a.version, b.version));
 }
 
-export function pickTopStats(stats: GroupedStats[], top: number) {
+export type FilterStatsOptions = {
+  totalDownloads: number;
+  all?: boolean;
+  top?: number;
+};
+
+export function filterStats(stats: GroupedStats[], options: FilterStatsOptions) {
+  if (options.all) {
+    return stats;
+  }
+
+  if (options.top) {
+    return pickTopStats(stats, options.top);
+  }
+
+  const downloadThreshold = 0.005 * options.totalDownloads; // 0.5%
+  return stats.filter((stat) => stat.downloads >= downloadThreshold);
+}
+
+function pickTopStats(stats: GroupedStats[], top: number) {
   const sortedStats = stats.sort((a, b) => b.downloads - a.downloads);
   const topStats = sortedStats.slice(0, top);
   return topStats.sort((a, b) => versionCompare(a.version, b.version));
-}
-
-export function pickMinimalDownloads(stats: GroupedStats[], minDownloads: number) {
-  return stats.filter((stat) => stat.downloads >= minDownloads);
 }

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -107,3 +107,7 @@ export function pickTopStats(stats: GroupedStats[], top: number) {
   const topStats = sortedStats.slice(0, top);
   return topStats.sort((a, b) => versionCompare(a.version, b.version));
 }
+
+export function pickMinimalDownloads(stats: GroupedStats[], minDownloads: number) {
+  return stats.filter((stat) => stat.downloads >= minDownloads);
+}


### PR DESCRIPTION
## What does this PR do?

By default hide versions with negligible share (below 0.5%). All versions can be show using `--all` (`-a`) flag.

## Relevant implementation details

This options is independent from `--top` option.

## How did you test this?

Manual runs.
