### PR TITLE
feat: compare packages

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import { parseCliOptions, showHelp } from './cli-options.js';
 import { comparePackages } from './mode/compare-packages.js';
-import { packageDetails } from './mode/package-details.js';
+import { printPackageStats } from './mode/package-stats.js';
 
 export async function pkgStats(argv: string[]) {
   let options;
@@ -18,7 +18,7 @@ export async function pkgStats(argv: string[]) {
   }
 
   if (options.packageNames.length === 1) {
-    await packageDetails(options.packageNames[0], options);
+    await printPackageStats(options.packageNames[0], options);
   } else {
     await comparePackages(options.packageNames, options);
   }

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -23,7 +23,7 @@ export function showHelp() {
 }
 
 export type CliOptions = {
-  packageName: string;
+  packageNames: string[];
   group?: 'major' | 'minor' | 'patch';
   top?: number;
   all?: boolean;
@@ -71,12 +71,12 @@ export function parseCliOptions(argv: string[]): CliOptions {
     cli.showHelp();
   }
 
-  if (!cli.input[0]) {
-    throw new Error('<package-name> is required');
+  if (!cli.input.length) {
+    throw new Error('At least one <package-name> is required');
   }
 
   return {
-    packageName: cli.input[0],
+    packageNames: cli.input,
     group: cli.flags.major
       ? 'major'
       : cli.flags.minor

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1,22 +1,62 @@
+import chalk from 'chalk';
 import meow from 'meow';
 import redent from 'redent';
 
 import { COLOR_SCHEMES, type ColorScheme } from './colors.js';
 
-const HELP = `
-pkg-stats <package-name>
+const colorCommand = chalk.hex('#22c1c3');
+const colorOption = chalk.hex('#fdbb2d');
 
-Show NPM weekly downloads stats for a package
+const HELP = `
+  ${colorCommand('pkg-stats')} <package> - Show version stats
+  ${colorCommand('pkg-stats')} <package-1> <package-2>... - Compare between packages
 
 Options:
-  -h, --help            Show help
-  --major               Group by major version
-  --minor               Group by minor version
-  --patch               Group by patch version
-  -t, --top <number>    Show top <number> versions
-  -a, --all             Show ALL versions (even negligible ones)
-  -c, --color <color>   Color scheme: ${COLOR_SCHEMES.sort().join(', ')}
+  ${colorOption('--major')}               Group by major version
+  ${colorOption('--minor')}               Group by minor version
+  ${colorOption('--patch')}               Group by patch version
+  ${colorOption('-t, --top')} <number>    Show top <number> most downloaded versions
+  ${colorOption(
+    '-a, --all',
+  )}             Include all versions in output, even those with minimal downloads
+  ${colorOption('-c, --color')} <scheme>  ${wrapOption(
+  `Choose color scheme from: ${COLOR_SCHEMES.sort().join(', ')}`,
+  50,
+  24,
+)}
+
+Examples:
+  ${chalk.dim('# Show stats for react')}
+  ${colorCommand('pkg-stats')} react
+
+  ${chalk.dim('# Compare react, vue, angular and svelte')}
+  ${colorCommand('pkg-stats')} react vue @angular/core svelte
+
+  ${chalk.dim('# Show top 10 major versions of lodash')}
+  ${colorCommand('pkg-stats')} lodash ${colorOption('--major -t 10')}
 `;
+
+function wrapOption(text: string, maxLength: number, indent: number) {
+  const words = text.split(' ');
+
+  let result = '';
+  let currentLine = words[0];
+  for (let i = 1; i < words.length; i++) {
+    const nextCurrentLine = currentLine + ' ' + words[i];
+    if (nextCurrentLine.length <= maxLength) {
+      currentLine = nextCurrentLine;
+    } else {
+      result += `\n${currentLine}`;
+      currentLine = words[i];
+    }
+  }
+
+  if (currentLine) {
+    result += `\n${currentLine}`;
+  }
+
+  return redent(result.trim(), indent).trim();
+}
 
 export function showHelp() {
   console.log(redent(HELP, 2));
@@ -34,7 +74,7 @@ export function parseCliOptions(argv: string[]): CliOptions {
   const cli = meow(HELP, {
     argv: argv.slice(2),
     autoHelp: true,
-    description: 'Show NPM weekly downloads stats for a package',
+    description: 'Show NPM weekly downloads stats:',
     importMeta: import.meta,
     flags: {
       help: {

--- a/src/mode/compare-packages.ts
+++ b/src/mode/compare-packages.ts
@@ -35,11 +35,16 @@ export async function comparePackages(packageNames: string[], options: CliOption
     packageNames.map((packageName) => fetchPackageData(packageName)),
   );
 
-  console.log(chalk.bold(`\nNPM weekly downloads\n`));
-
   const packagesToDisplay = rawPackages
     .filter((pkg) => pkg !== undefined)
     .sort((a, b) => b.downloads - a.downloads);
+
+  if (packagesToDisplay.length === 0) {
+    console.error(chalk.red('\nNo packages found.\n'));
+    process.exit(1);
+  }
+
+  console.log(chalk.bold(`\nNPM weekly downloads\n`));
 
   const maxDownloads = Math.max(...packagesToDisplay.map((v) => v.downloads));
   const displayData = packagesToDisplay.map((item) => {

--- a/src/mode/compare-packages.ts
+++ b/src/mode/compare-packages.ts
@@ -1,0 +1,64 @@
+import chalk from 'chalk';
+
+import { renderChart } from '../chart.js';
+import { type CliOptions } from '../cli-options.js';
+import { getColors } from '../colors.js';
+import { formatDownloads } from '../format.js';
+import { fetchNpmLastWeekDownloads } from '../npm-api.js';
+
+type PackageData = {
+  packageName: string;
+  downloads: number;
+};
+
+async function fetchPackageData(packageName: string): Promise<PackageData | undefined> {
+  try {
+    const data = await fetchNpmLastWeekDownloads(packageName);
+
+    if (!Object.keys(data.downloads).length) {
+      console.warn(chalk.yellow(`No data found for package "${packageName}".`));
+      return undefined;
+    }
+
+    return {
+      packageName,
+      downloads: Object.values(data.downloads).reduce((sum, downloads) => sum + downloads, 0),
+    };
+  } catch (error) {
+    console.warn(chalk.yellow(`Failed to fetch data for package "${packageName}"`, error));
+    return undefined;
+  }
+}
+
+export async function comparePackages(packageNames: string[], options: CliOptions) {
+  const rawPackages = await Promise.all(
+    packageNames.map((packageName) => fetchPackageData(packageName)),
+  );
+
+  console.log(chalk.bold(`\nNPM weekly downloads\n`));
+
+  const packagesToDisplay = rawPackages
+    .filter((pkg) => pkg !== undefined)
+    .sort((a, b) => b.downloads - a.downloads);
+
+  const maxDownloads = Math.max(...packagesToDisplay.map((v) => v.downloads));
+  const displayData = packagesToDisplay.map((item) => {
+    return {
+      name: item.packageName,
+      chart: renderChart(item.downloads / maxDownloads),
+      downloads: formatDownloads(item.downloads, maxDownloads),
+    };
+  });
+
+  const maxNameLength = Math.max(...displayData.map((item) => item.name.length));
+  const maxDownloadsLength = Math.max(...displayData.map((item) => item.downloads.length));
+  const colors = getColors(packagesToDisplay.length, options.color);
+  displayData.forEach((item, i) => {
+    const color = chalk.hex(colors[i]);
+    console.log(
+      `${item.name.padStart(2 + maxNameLength)} ${color(item.chart)} ${color(
+        item.downloads.padStart(maxDownloadsLength),
+      )}`,
+    );
+  });
+}

--- a/src/mode/compare-packages.ts
+++ b/src/mode/compare-packages.ts
@@ -11,25 +11,6 @@ type PackageData = {
   downloads: number;
 };
 
-async function fetchPackageData(packageName: string): Promise<PackageData | undefined> {
-  try {
-    const data = await fetchNpmLastWeekDownloads(packageName);
-
-    if (!Object.keys(data.downloads).length) {
-      console.warn(chalk.yellow(`No data found for package "${packageName}".`));
-      return undefined;
-    }
-
-    return {
-      packageName,
-      downloads: Object.values(data.downloads).reduce((sum, downloads) => sum + downloads, 0),
-    };
-  } catch (error) {
-    console.warn(chalk.yellow(`Failed to fetch data for package "${packageName}"`, error));
-    return undefined;
-  }
-}
-
 export async function comparePackages(packageNames: string[], options: CliOptions) {
   const rawPackages = await Promise.all(
     packageNames.map((packageName) => fetchPackageData(packageName)),
@@ -66,4 +47,23 @@ export async function comparePackages(packageNames: string[], options: CliOption
       )}`,
     );
   });
+}
+
+async function fetchPackageData(packageName: string): Promise<PackageData | undefined> {
+  try {
+    const data = await fetchNpmLastWeekDownloads(packageName);
+
+    if (!Object.keys(data.downloads).length) {
+      console.warn(chalk.yellow(`No data found for package "${packageName}".`));
+      return undefined;
+    }
+
+    return {
+      packageName,
+      downloads: Object.values(data.downloads).reduce((sum, downloads) => sum + downloads, 0),
+    };
+  } catch (error) {
+    console.warn(chalk.yellow(`Failed to fetch data for package "${packageName}"`, error));
+    return undefined;
+  }
 }

--- a/src/mode/package-details.ts
+++ b/src/mode/package-details.ts
@@ -1,0 +1,72 @@
+import chalk from 'chalk';
+
+import { renderChart } from '../chart.js';
+import { type CliOptions } from '../cli-options.js';
+import { getColors } from '../colors.js';
+import { formatDownloads } from '../format.js';
+import { fetchNpmLastWeekDownloads, type NpmLastWeekDownloadsResponse } from '../npm-api.js';
+import { filterStats, groupStats } from '../stats.js';
+import { parseVersion, versionCompare } from '../version.js';
+
+export async function packageDetails(packageName: string, options: CliOptions) {
+  let data: NpmLastWeekDownloadsResponse;
+  try {
+    data = await fetchNpmLastWeekDownloads(packageName);
+  } catch (error) {
+    console.error(`Failed to fetch data for package "${packageName}"`, error);
+    return;
+  }
+
+  if (!Object.keys(data.downloads).length) {
+    console.error(`No data found for package "${packageName}".\n`);
+    process.exit(1);
+  }
+
+  const npmStats = Object.keys(data.downloads)
+    .map((versionString) => {
+      const version = parseVersion(versionString);
+      return {
+        ...version,
+        downloads: data.downloads[versionString],
+      };
+    })
+    .sort(versionCompare);
+
+  const { type, stats } = groupStats(npmStats, options.group);
+  const totalDownloads = Object.values(stats).reduce((sum, version) => sum + version.downloads, 0);
+
+  const statsToDisplay = filterStats(stats, {
+    totalDownloads,
+    all: options.all,
+    top: options.top,
+  });
+
+  const colors = getColors(statsToDisplay.length, options.color);
+  const primaryColor = chalk.hex(colors[0]);
+
+  console.log(chalk.bold(`\nNPM weekly downloads for ${primaryColor(packageName)}\n`));
+  console.log(`Total: ${primaryColor(totalDownloads.toLocaleString())} last week\n`);
+
+  console.log(options.top ? `Top ${options.top} ${type} versions:\n` : `By ${type} version:\n`);
+
+  const maxDownloads = Math.max(...stats.map((v) => v.downloads));
+  const displayData = statsToDisplay.map((item) => {
+    const versionParts = item.versionString.split('.');
+    return {
+      version: versionParts.length < 3 ? `${item.versionString}.x` : item.versionString,
+      chart: renderChart(item.downloads / maxDownloads),
+      downloads: formatDownloads(item.downloads, maxDownloads),
+    };
+  });
+
+  const maxVersionLength = Math.max(...displayData.map((item) => item.version.length));
+  const maxDownloadsLength = Math.max(...displayData.map((item) => item.downloads.length));
+  displayData.forEach((item, i) => {
+    const color = chalk.hex(colors[i]);
+    console.log(
+      `${item.version.padStart(2 + maxVersionLength)} ${color(item.chart)} ${color(
+        item.downloads.padStart(maxDownloadsLength),
+      )}`,
+    );
+  });
+}

--- a/src/mode/package-stats.ts
+++ b/src/mode/package-stats.ts
@@ -8,7 +8,7 @@ import { fetchNpmLastWeekDownloads, type NpmLastWeekDownloadsResponse } from '..
 import { filterStats, groupStats } from '../stats.js';
 import { parseVersion, versionCompare } from '../version.js';
 
-export async function packageDetails(packageName: string, options: CliOptions) {
+export async function printPackageStats(packageName: string, options: CliOptions) {
   let data: NpmLastWeekDownloadsResponse;
   try {
     data = await fetchNpmLastWeekDownloads(packageName);


### PR DESCRIPTION
## What does this PR do?

Resolves #11

Separate mode for comparing different packages

<img width="593" alt="image" src="https://github.com/user-attachments/assets/e095d26c-d24d-4bcd-8df7-49d150ddc97f" />

For single package it still behaves as previously, i.e. display downloads by version.

## Relevant implementation details

- `mode/package-details.ts` - basic mode
- `mode/compare-packges.ts` - compare mode

Handles package download issues by displaying warnings for non-existing packages.

## How did you test this?

Manual testing.