### PR TITLE
feat: dynamic chart width

### DIFF
--- a/src/__tests__/output.test.ts
+++ b/src/__tests__/output.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { formatBar } from '../output.js';
 
 test('renderChart basic tests', () => {
-  expect(formatBar(0.0, { length: 10 })).toMatchInlineSnapshot(`"▏         "`);
-  expect(formatBar(0.5, { length: 10 })).toMatchInlineSnapshot(`"█████     "`);
-  expect(formatBar(1.0, { length: 10 })).toMatchInlineSnapshot(`"██████████"`);
+  expect(formatBar(0.0, { width: 10 })).toMatchInlineSnapshot(`"▏         "`);
+  expect(formatBar(0.5, { width: 10 })).toMatchInlineSnapshot(`"█████     "`);
+  expect(formatBar(1.0, { width: 10 })).toMatchInlineSnapshot(`"██████████"`);
 });

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -19,7 +19,6 @@ Options:
   ${colorOption(
     '-a, --all',
   )}             Include all versions in output, even those with minimal downloads
-  ${colorOption('-x, --extended')}        Show extended stats
   ${colorOption('-c, --color')} <scheme>  ${wrapOption(
   `Choose color scheme from: ${COLOR_SCHEMES.sort().join(', ')}`,
   50,
@@ -68,7 +67,6 @@ export type CliOptions = {
   group?: 'major' | 'minor' | 'patch';
   top?: number;
   all: boolean;
-  extended: boolean;
   color: ColorScheme;
 };
 
@@ -101,10 +99,6 @@ export function parseCliOptions(argv: string[]): CliOptions {
         type: 'boolean',
         shortFlag: 'a',
       },
-      extended: {
-        type: 'boolean',
-        shortFlag: 'x',
-      },
       color: {
         shortFlag: 'c',
         type: 'string',
@@ -132,7 +126,6 @@ export function parseCliOptions(argv: string[]): CliOptions {
       : undefined,
     top: cli.flags.top,
     all: cli.flags.all ?? false,
-    extended: cli.flags.extended ?? false,
     color: coalesceColor(cli.flags.color ?? process.env.PKG_STATS_COLOR_SCHEME) ?? getColorOfDay(),
   };
 }

--- a/src/mode/compare-packages.ts
+++ b/src/mode/compare-packages.ts
@@ -29,7 +29,7 @@ export async function comparePackages(packageNames: string[], options: CliOption
   const items = packagesToDisplay.map((item) => ({
     label: item.packageName,
     value: item.downloads,
-    extended: options.extended ? formatPercentage(item.downloads / maxDownloads) : undefined,
+    extra: formatPercentage(item.downloads / maxDownloads),
   }));
 
   printChart(items, {

--- a/src/mode/package-stats.ts
+++ b/src/mode/package-stats.ts
@@ -58,7 +58,7 @@ export async function printPackageStats(packageName: string, options: CliOptions
   const items = statsToDisplay.map((item) => ({
     label: item.versionString,
     value: item.downloads,
-    extended: options.extended ? formatPercentage(item.downloads / totalDownloads) : undefined,
+    extra: formatPercentage(item.downloads / totalDownloads),
   }));
 
   printChart(items, {

--- a/src/output.ts
+++ b/src/output.ts
@@ -24,10 +24,13 @@ export function printChart(items: ChartItem[], options: PrintChartOptions) {
   const colors = getColors(items.length, options.colorScheme);
   const indent = options.indent ?? 0;
 
+  const chartWidth =
+    getTerminalWidth() - indent - maxLabelLength - maxValueLength - maxExtendedLength - 4;
+
   items.forEach((item, i) => {
     const color = chalk.hex(colors[i]);
     const label = ' '.repeat(indent) + item.label.padStart(maxLabelLength);
-    const bar = formatBar(item.value / maxValue);
+    const bar = formatBar(item.value / maxValue, { width: clamp(chartWidth, 30, 60) });
     const value = formatDownloads(item.value, maxValue).padStart(maxValueLength);
     const extended = item.extended
       ? chalk.dim(` ${item.extended}`.padStart(maxExtendedLength + 1))
@@ -38,14 +41,22 @@ export function printChart(items: ChartItem[], options: PrintChartOptions) {
 }
 
 type FormatBarOptions = {
-  length?: number;
+  width?: number;
 };
 
-export function formatBar(value: number, { length = 50 }: FormatBarOptions = {}) {
-  const filledChars = Math.round(value * length);
+export function formatBar(value: number, { width = 50 }: FormatBarOptions = {}) {
+  const filledChars = Math.round(value * width);
   if (filledChars === 0) {
-    return '▏' + ' '.repeat(length - 1);
+    return '▏' + ' '.repeat(width - 1);
   }
 
-  return '█'.repeat(filledChars) + ' '.repeat(length - filledChars);
+  return '█'.repeat(filledChars) + ' '.repeat(width - filledChars);
+}
+
+export function getTerminalWidth() {
+  return process.stdout.columns;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -6,7 +6,7 @@ import { formatDownloads } from './format.js';
 export type ChartItem = {
   label: string;
   value: number;
-  extended?: string;
+  extra?: string;
 };
 
 export type PrintChartOptions = {
@@ -19,24 +19,22 @@ export function printChart(items: ChartItem[], options: PrintChartOptions) {
 
   const maxValue = Math.max(...items.map((item) => item.value));
   const maxValueLength = formatDownloads(maxValue, maxValue).length;
-  const maxExtendedLength = Math.max(...items.map((item) => item.extended?.length ?? 0));
+  const maxExtraLength = Math.max(...items.map((item) => item.extra?.length ?? 0));
 
   const colors = getColors(items.length, options.colorScheme);
   const indent = options.indent ?? 0;
 
   const chartWidth =
-    getTerminalWidth() - indent - maxLabelLength - maxValueLength - maxExtendedLength - 4;
+    getTerminalWidth() - indent - maxLabelLength - maxValueLength - maxExtraLength - 5;
 
   items.forEach((item, i) => {
     const color = chalk.hex(colors[i]);
     const label = ' '.repeat(indent) + item.label.padStart(maxLabelLength);
     const bar = formatBar(item.value / maxValue, { width: clamp(chartWidth, 30, 60) });
     const value = formatDownloads(item.value, maxValue).padStart(maxValueLength);
-    const extended = item.extended
-      ? chalk.dim(` ${item.extended}`.padStart(maxExtendedLength + 1))
-      : '';
+    const extra = item.extra ? chalk.dim(` ${item.extra}`.padStart(maxExtraLength + 1)) : '';
 
-    console.log(`${label} ${color(bar)} ${color(value)}${extended}`);
+    console.log(`${label} ${color(bar)} ${color(value)}${extra}`);
   });
 }
 


### PR DESCRIPTION
## What does this PR do?

Dynamically adjust width of the chart in range of 30 and 60 chars, depending on terminal width and other displayed data.

## Relevant implementation details

## How did you test this?
